### PR TITLE
Send mail via local MTA and remove Ableton specific email addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 Provides configuration management and error reporting infrastructure
 for cronjobs and asynchronous services.
 
+## Running tests
+
+Tests can be run via nose (`pip install nose`):
+
+    nosetests
+
 ## How to release a new version
 
 This package uses versioneer to manage version numbers.

--- a/abl/robot/base.py
+++ b/abl/robot/base.py
@@ -9,7 +9,6 @@ __docformat__ = "restructuredtext en"
 
 import sys
 import os
-import pprint
 import subprocess
 from urllib import urlopen
 from cStringIO import StringIO
@@ -262,7 +261,7 @@ class Robot(object):
         mail=dedent("""
         [mail]
         transport = option(smtp, debug, default=smtp)
-        smtp.server = string(default=mail.ableton.net)
+        smtp.server = string(default=localhost)
         """),
         logging=dedent("""
         [logging]
@@ -319,7 +318,7 @@ class Robot(object):
     This of course requires the email config being set up properly.
     """
 
-    AUTHOR = "dir@ableton.com" # FIXME-dir: this must become robot@ableton.com or similar.
+    AUTHOR = "robot@localhost"
 
     LOCK_TERMINATION_MESSAGE = """Terminating because the lock was active."""
 

--- a/abl/robot/mail.py
+++ b/abl/robot/mail.py
@@ -87,7 +87,7 @@ def configure(conf):
     default_conf = {
         "manager" :             "immediate",
         "transport" :           "smtp",
-        "smtp.server" :         "mail.ableton.net",
+        "smtp.server" :         "localhost",
         "message.encoding" :    "utf-8",
         "utf8qp.on" :           True,
         }

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -7,25 +7,13 @@ from __future__ import with_statement
 __docformat__ = "restructuredtext en"
 
 import os
-import sys
-import time
-import threading
-import logging
-from functools import partial
-import unittest
-import contextlib
 import tempfile
-import subprocess
 from textwrap import dedent
 
 import shutil
-from urllib import urlencode
 
 from abl.robot import Robot
 from abl.robot.test import RobotTestCase
-
-
-from abl.vpath.base import URI
 
 
 class BasicRobotTests(RobotTestCase):
@@ -35,8 +23,8 @@ class BasicRobotTests(RobotTestCase):
 
         class FailBot(Robot):
 
-            AUTHOR = "dir@ableton.com"
-            EXCEPTION_MAILING = "dir@ableton.com"
+            AUTHOR = "robot@example.com"
+            EXCEPTION_MAILING = "robot@example.com"
 
             def work(self):
                 raise Exception("Oh lord forgive me, I'm such an epic fail!")
@@ -94,8 +82,8 @@ class BasicRobotTests(RobotTestCase):
 
         class RaiseBot(Robot):
 
-            AUTHOR = "dir@ableton.com"
-            EXCEPTION_MAILING = "dir@ableton.com"
+            AUTHOR = "robot@example.com"
+            EXCEPTION_MAILING = "robot@example.com"
 
             def work(self):
                 raise Foo
@@ -125,8 +113,8 @@ class BasicRobotTests(RobotTestCase):
 
         class ConfigBot(Robot):
 
-            AUTHOR = "dir@ableton.com"
-            EXCEPTION_MAILING = "dir@ableton.com"
+            AUTHOR = "robot@example.com"
+            EXCEPTION_MAILING = "robot@example.com"
 
             NEEDS_CONFIG = True
 


### PR DESCRIPTION
@dir-ableton @mattpatey We prefer to queue emails locally if we can't reach the remote SMTP server. As this is open source, I think it makes sense to strip Ableton-specific configuration.
