### PR TITLE
Log any unhandled exception

### DIFF
--- a/abl/robot/base.py
+++ b/abl/robot/base.py
@@ -436,10 +436,10 @@ class Robot(object):
         except (KeyboardInterrupt, SystemExit):
             pass
         except:
+            self.logger.exception("An unhandled exception occured.")
             if self.raise_exceptions:
                 raise
             self.error_handler.report_exception()
-            self.logger.exception("An unhandled exception occured.")
 
 
     def sendmail(self, subject, to, text=None, attachments=()):

--- a/abl/robot/base.py
+++ b/abl/robot/base.py
@@ -439,6 +439,7 @@ class Robot(object):
             if self.raise_exceptions:
                 raise
             self.error_handler.report_exception()
+            self.logger.exception("An unhandled exception occured.")
 
 
     def sendmail(self, subject, to, text=None, attachments=()):

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -8,7 +8,7 @@ __docformat__ = "restructuredtext en"
 
 import os
 import tempfile
-from logging import DEBUG,  Handler
+from logging import Handler
 from textwrap import dedent
 
 import shutil


### PR DESCRIPTION
Pivotal: Addendum to https://www.pivotaltracker.com/story/show/126583801

This allows us to get rid of SentryReporter in robots  because SentryHandler would also handle uncaught exceptions.
